### PR TITLE
update 升级aiohttp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ uvicorn==0.14.0
 requests
 pymongo==4.0.1
 dnspython==2.2.0
-aiohttp==3.8.1
+aiohttp==3.9.0rc0
 colorama


### PR DESCRIPTION
修复verlcel部署失败的bug，详见issue:https://github.com/aio-libs/aiohttp/issues/7675